### PR TITLE
Restore Dispatcher::use_routes after LinkTest to fix CI test pollution

### DIFF
--- a/tests/Integration/Classes/LinkTest.php
+++ b/tests/Integration/Classes/LinkTest.php
@@ -12,9 +12,34 @@ use Context;
 use Dispatcher;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionProperty;
 
 class LinkTest extends TestCase
 {
+    private $originalUseRoutes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalUseRoutes = $this->getUseRoutesProperty()->getValue(Dispatcher::getInstance());
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore the Dispatcher singleton state mutated by the tests, otherwise the forced
+        // use_routes value leaks into other test classes and changes their generated URLs.
+        $this->getUseRoutesProperty()->setValue(Dispatcher::getInstance(), $this->originalUseRoutes);
+        parent::tearDown();
+    }
+
+    private function getUseRoutesProperty(): ReflectionProperty
+    {
+        $property = (new ReflectionClass('Dispatcher'))->getProperty('use_routes');
+        $property->setAccessible(true);
+
+        return $property;
+    }
+
     private function getProductLink(bool $statusUseRoutes, int $id_product, ?int $id_product_attribute): array
     {
         $reflectionDispatcher = new ReflectionClass('Dispatcher');


### PR DESCRIPTION
Hi @Codencode 👋 — fix for the CI failure you flagged on PrestaShop/PrestaShop#41808.

**Root cause:** it isn't `testSupplierUrlOmitsMetaTitleWhenRouteHasNoMetaTitleKeyword()` asserting wrong — it's **test pollution**. That test (and the existing `LinkTest` ones) force `Dispatcher::use_routes` via reflection on the **singleton** but never restore it. My supplier test leaves it `true`, which leaks into later test classes in the same process — `AdminSearchControllerCoreTest` and `LegacyUrlConverterTest` — so their generated admin URLs lose/gain `index.php` (exactly the 4 failures: `/admin-dev/?...` vs `/admin-dev/index.php?...`).

**Fix:** save `use_routes` in `setUp()` and restore it in `tearDown()`, so no `LinkTest` test leaks Dispatcher state.

I reproduced it on `develop` (added a use_routes-leaking test → `LegacyUrlConverterTest` failed with the same `index.php` diff) and confirmed the `setUp`/`tearDown` restore makes both classes pass together (477 tests OK). Couldn't run the 9.1.x integration suite locally (test-DB version pin), but the fix is generic.

Opened it as a PR into your branch — feel free to squash it in.
